### PR TITLE
Async Image Fetch

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -138,6 +138,7 @@ export class Gif {
 		const Canvas = canvas.createCanvas(this.width, this.height)
 		const ctx = Canvas.getContext('2d')
 		const encoder = new GIFEncoder(this.width, this.height)
+		const promises = [];
 
 		encoder.start()
 		encoder.setRepeat(this.repeat ? 0 : -1)
@@ -157,30 +158,19 @@ export class Gif {
 						ctx.fillStyle = Frame.background
 						ctx.fillRect(0, 0, Canvas.width, Canvas.height)
 					} else {
-						const BackgroundImage = await canvas.loadImage(
-							Frame.background
-						)
-
-						ctx.drawImage(
-							BackgroundImage,
-							0,
-							0,
-							Canvas.width,
-							Canvas.height
-						)
+						promises.push(canvas.loadImage(Frame.background))
 					}
 				} else {
-					const Image = await canvas.loadImage(Frame.src)
-
-					ctx.drawImage(Image, 0, 0, Canvas.width, Canvas.height)
+					promises.push(canvas.loadImage(Frame.src))
 				}
 			}
-
-			encoder.addFrame(ctx)
-
-			ctx.clearRect(0, 0, Canvas.width, Canvas.height)
 		}
 
+		for (const Image of await Promise.all(promises)) {
+			ctx.drawImage(Image, 0, 0, Canvas.width, Canvas.height)
+			encoder.addFrame(ctx)
+			ctx.clearRect(0, 0, Canvas.width, Canvas.height)
+		}
 		return encoder.out.getData()
 	}
 }


### PR DESCRIPTION
Instead of fetching and building the frame synchronous I pushed all fetch-promises to an array and only after fetching creating the frames.
This makes the fetching non-blocking because multiple fetch requests can be open att once instead of waiting on the previous one to finish before starting a new one.
This also makes the code simpler and less repeating.